### PR TITLE
Add simple web UI

### DIFF
--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -14,6 +14,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/admin/src/main/java/io/meshspy/meshspy_server/node/Node.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/node/Node.java
@@ -1,0 +1,39 @@
+package io.meshspy.meshspy_server.node;
+
+public class Node {
+    private String id;
+    private String name;
+    private String address;
+
+    public Node() {}
+
+    public Node(String id, String name, String address) {
+        this.id = id;
+        this.name = name;
+        this.address = address;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+}

--- a/admin/src/main/java/io/meshspy/meshspy_server/node/NodeController.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/node/NodeController.java
@@ -1,0 +1,32 @@
+package io.meshspy.meshspy_server.node;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/nodes")
+public class NodeController {
+    private final NodeService nodeService;
+
+    public NodeController(NodeService nodeService) {
+        this.nodeService = nodeService;
+    }
+
+    @GetMapping
+    public List<Node> listNodes() {
+        return nodeService.listNodes();
+    }
+
+    @GetMapping("/{id}")
+    public Node getNode(@PathVariable String id) {
+        return nodeService.getNode(id).orElseThrow(() -> new NodeNotFoundException(id));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Node addNode(@RequestBody Node node) {
+        return nodeService.addNode(node);
+    }
+}

--- a/admin/src/main/java/io/meshspy/meshspy_server/node/NodeNotFoundException.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/node/NodeNotFoundException.java
@@ -1,0 +1,11 @@
+package io.meshspy.meshspy_server.node;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class NodeNotFoundException extends RuntimeException {
+    public NodeNotFoundException(String id) {
+        super("Node not found: " + id);
+    }
+}

--- a/admin/src/main/java/io/meshspy/meshspy_server/node/NodeService.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/node/NodeService.java
@@ -1,0 +1,23 @@
+package io.meshspy.meshspy_server.node;
+
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+public class NodeService {
+    private final Map<String, Node> nodes = new HashMap<>();
+
+    public List<Node> listNodes() {
+        return new ArrayList<>(nodes.values());
+    }
+
+    public Optional<Node> getNode(String id) {
+        return Optional.ofNullable(nodes.get(id));
+    }
+
+    public Node addNode(Node node) {
+        nodes.put(node.getId(), node);
+        return node;
+    }
+}

--- a/admin/src/main/resources/static/app.js
+++ b/admin/src/main/resources/static/app.js
@@ -1,0 +1,29 @@
+async function loadNodes() {
+    const response = await fetch('/nodes');
+    const nodes = await response.json();
+    const tbody = document.querySelector('#nodes tbody');
+    tbody.innerHTML = '';
+    nodes.forEach(n => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${n.id}</td><td>${n.name}</td><td>${n.address}</td>`;
+        tbody.appendChild(tr);
+    });
+}
+
+document.getElementById('node-form').addEventListener('submit', async e => {
+    e.preventDefault();
+    const node = {
+        id: document.getElementById('node-id').value,
+        name: document.getElementById('node-name').value,
+        address: document.getElementById('node-address').value
+    };
+    await fetch('/nodes', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(node)
+    });
+    e.target.reset();
+    loadNodes();
+});
+
+loadNodes();

--- a/admin/src/main/resources/static/index.html
+++ b/admin/src/main/resources/static/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MeshSpy Admin</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="container">
+    <h1>MeshSpy Node Administration</h1>
+    <div id="node-list" class="card">
+        <h2>Nodes</h2>
+        <table id="nodes">
+            <thead><tr><th>ID</th><th>Name</th><th>Address</th></tr></thead>
+            <tbody></tbody>
+        </table>
+    </div>
+    <div id="add-node" class="card">
+        <h2>Add Node</h2>
+        <form id="node-form">
+            <label>ID <input type="text" id="node-id" required></label>
+            <label>Name <input type="text" id="node-name" required></label>
+            <label>Address <input type="text" id="node-address" required></label>
+            <button type="submit">Add</button>
+        </form>
+    </div>
+</div>
+<script src="app.js"></script>
+</body>
+</html>

--- a/admin/src/main/resources/static/style.css
+++ b/admin/src/main/resources/static/style.css
@@ -1,0 +1,52 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f0f2f5;
+    margin: 0;
+    padding: 0;
+}
+
+.container {
+    max-width: 800px;
+    margin: 40px auto;
+    padding: 20px;
+}
+
+.card {
+    background: white;
+    padding: 20px;
+    margin-bottom: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+thead {
+    background: #eee;
+}
+
+td, th {
+    padding: 8px;
+    border: 1px solid #ccc;
+}
+
+label {
+    display: block;
+    margin-bottom: 10px;
+}
+
+input {
+    margin-left: 10px;
+}
+
+button {
+    padding: 8px 16px;
+    background-color: #007bff;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}

--- a/admin/src/test/java/io/meshspy/meshspy_server/node/NodeControllerTests.java
+++ b/admin/src/test/java/io/meshspy/meshspy_server/node/NodeControllerTests.java
@@ -1,0 +1,43 @@
+package io.meshspy.meshspy_server.node;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class NodeControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void addAndGetNode() throws Exception {
+        Node node = new Node("1", "Test", "localhost");
+
+        mockMvc.perform(post("/nodes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(node)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/nodes/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Test"));
+    }
+
+    @Test
+    void uiAvailable() throws Exception {
+        mockMvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML));
+    }
+}


### PR DESCRIPTION
## Summary
- serve static web UI in Admin module
- page lists nodes and has form to add nodes
- add tests checking UI availability

## Testing
- `mvn test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686cdc54b3c483239ea1c06574b30cd5