### PR TITLE
Add simple map view

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ npm run dev
 
 The UI will be accessible at `http://localhost:5173` (currently under development).
 
+### Admin Module
+
+A minimal Spring Boot admin interface is available under the `admin` module.
+You can run it with Docker Compose:
+
+```bash
+docker compose up debug-admin
+```
+
+Once started, open `http://localhost:8080` to access a simple page showing the list of nodes and an interactive map.
+
 ## Planned MQTT Configuration
 
 The MQTT broker configuration is planned through a `config.json` file:

--- a/admin/src/main/java/io/meshspy/meshspy_server/node/Node.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/node/Node.java
@@ -4,13 +4,18 @@ public class Node {
     private String id;
     private String name;
     private String address;
+    private Double latitude;
+    private Double longitude;
 
-    public Node() {}
+    public Node() {
+    }
 
-    public Node(String id, String name, String address) {
+    public Node(String id, String name, String address, Double latitude, Double longitude) {
         this.id = id;
         this.name = name;
         this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
     }
 
     public String getId() {
@@ -35,5 +40,21 @@ public class Node {
 
     public void setAddress(String address) {
         this.address = address;
+    }
+
+    public Double getLatitude() {
+        return latitude;
+    }
+
+    public void setLatitude(Double latitude) {
+        this.latitude = latitude;
+    }
+
+    public Double getLongitude() {
+        return longitude;
+    }
+
+    public void setLongitude(Double longitude) {
+        this.longitude = longitude;
     }
 }

--- a/admin/src/main/resources/static/app.js
+++ b/admin/src/main/resources/static/app.js
@@ -1,12 +1,21 @@
+let map;
+let markers = [];
+
 async function loadNodes() {
     const response = await fetch('/nodes');
     const nodes = await response.json();
     const tbody = document.querySelector('#nodes tbody');
     tbody.innerHTML = '';
+    markers.forEach(m => m.remove());
+    markers = [];
     nodes.forEach(n => {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${n.id}</td><td>${n.name}</td><td>${n.address}</td>`;
+        tr.innerHTML = `<td>${n.id}</td><td>${n.name}</td><td>${n.address}</td><td>${n.latitude ?? ''}</td><td>${n.longitude ?? ''}</td>`;
         tbody.appendChild(tr);
+        if (n.latitude != null && n.longitude != null && map) {
+            const marker = L.marker([n.latitude, n.longitude]).addTo(map).bindPopup(n.name);
+            markers.push(marker);
+        }
     });
 }
 
@@ -15,7 +24,9 @@ document.getElementById('node-form').addEventListener('submit', async e => {
     const node = {
         id: document.getElementById('node-id').value,
         name: document.getElementById('node-name').value,
-        address: document.getElementById('node-address').value
+        address: document.getElementById('node-address').value,
+        latitude: parseFloat(document.getElementById('node-lat').value),
+        longitude: parseFloat(document.getElementById('node-lon').value)
     };
     await fetch('/nodes', {
         method: 'POST',
@@ -26,4 +37,13 @@ document.getElementById('node-form').addEventListener('submit', async e => {
     loadNodes();
 });
 
+function initMap() {
+    map = L.map('map').setView([0, 0], 2);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+        attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+}
+
+initMap();
 loadNodes();

--- a/admin/src/main/resources/static/index.html
+++ b/admin/src/main/resources/static/index.html
@@ -12,20 +12,25 @@
     <div id="node-list" class="card">
         <h2>Nodes</h2>
         <table id="nodes">
-            <thead><tr><th>ID</th><th>Name</th><th>Address</th></tr></thead>
+            <thead><tr><th>ID</th><th>Name</th><th>Address</th><th>Lat</th><th>Lon</th></tr></thead>
             <tbody></tbody>
         </table>
     </div>
+    <div id="map" class="card" style="height: 400px;"></div>
     <div id="add-node" class="card">
         <h2>Add Node</h2>
         <form id="node-form">
             <label>ID <input type="text" id="node-id" required></label>
             <label>Name <input type="text" id="node-name" required></label>
             <label>Address <input type="text" id="node-address" required></label>
+            <label>Latitude <input type="number" id="node-lat" step="any"></label>
+            <label>Longitude <input type="number" id="node-lon" step="any"></label>
             <button type="submit">Add</button>
         </form>
     </div>
 </div>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-sA+e2d0n0JdfM8KcVpN2zsJxxavq6b3cXwjk2f2ol3w=" crossorigin=""/>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o1a30jow+/5T1vZ1UUvlFRYHb00nKTT0RP70dNDOJYw=" crossorigin=""></script>
 <script src="app.js"></script>
 </body>
 </html>

--- a/admin/src/main/resources/static/style.css
+++ b/admin/src/main/resources/static/style.css
@@ -50,3 +50,7 @@ button {
     border-radius: 4px;
     cursor: pointer;
 }
+
+#map {
+    height: 400px;
+}

--- a/admin/src/test/java/io/meshspy/meshspy_server/node/NodeControllerTests.java
+++ b/admin/src/test/java/io/meshspy/meshspy_server/node/NodeControllerTests.java
@@ -22,7 +22,7 @@ class NodeControllerTests {
 
     @Test
     void addAndGetNode() throws Exception {
-        Node node = new Node("1", "Test", "localhost");
+        Node node = new Node("1", "Test", "localhost", 0.0, 0.0);
 
         mockMvc.perform(post("/nodes")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -38,5 +38,5 @@ class NodeControllerTests {
     void uiAvailable() throws Exception {
         mockMvc.perform(get("/"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML));
-    }
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML));    }
+}


### PR DESCRIPTION
## Summary
- enhance `Node` model with `latitude` and `longitude`
- show node coordinates and map in the admin UI
- integrate Leaflet map and markers
- document the admin module in the README
- fix tests to use new fields

## Testing
- `mvn -q -pl admin test` *(fails: Non-resolvable parent POM)*
- `mvn -q -pl admin -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686e11a64fc883238f46e176f0159a85