### PR TITLE
Implement node registration workflow

### DIFF
--- a/admin/src/main/java/io/meshspy/meshspy_server/node/NodeService.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/node/NodeService.java
@@ -1,5 +1,6 @@
 package io.meshspy.meshspy_server.node;
 
+import io.meshspy.meshspy_server.request.NodeRegistrationRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -7,6 +8,7 @@ import java.util.*;
 @Service
 public class NodeService {
     private final Map<String, Node> nodes = new HashMap<>();
+    private final Map<String, NodeRegistrationRequest> requests = new HashMap<>();
 
     public List<Node> listNodes() {
         return new ArrayList<>(nodes.values());
@@ -19,5 +21,25 @@ public class NodeService {
     public Node addNode(Node node) {
         nodes.put(node.getId(), node);
         return node;
+    }
+
+    public NodeRegistrationRequest addRequest(NodeRegistrationRequest request) {
+        requests.put(request.getId(), request);
+        return request;
+    }
+
+    public List<NodeRegistrationRequest> listRequests() {
+        return new ArrayList<>(requests.values());
+    }
+
+    public void approveRequest(String id) {
+        NodeRegistrationRequest request = requests.remove(id);
+        if (request != null) {
+            addNode(new Node(request.getId(), request.getName(), request.getAddress(), request.getLatitude(), request.getLongitude()));
+        }
+    }
+
+    public void rejectRequest(String id) {
+        requests.remove(id);
     }
 }

--- a/admin/src/main/java/io/meshspy/meshspy_server/request/NodeRegistrationRequest.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/request/NodeRegistrationRequest.java
@@ -1,0 +1,34 @@
+package io.meshspy.meshspy_server.request;
+
+public class NodeRegistrationRequest {
+    private String id;
+    private String name;
+    private String address;
+    private Double latitude;
+    private Double longitude;
+
+    public NodeRegistrationRequest() {}
+
+    public NodeRegistrationRequest(String id, String name, String address, Double latitude, Double longitude) {
+        this.id = id;
+        this.name = name;
+        this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getAddress() { return address; }
+    public void setAddress(String address) { this.address = address; }
+
+    public Double getLatitude() { return latitude; }
+    public void setLatitude(Double latitude) { this.latitude = latitude; }
+
+    public Double getLongitude() { return longitude; }
+    public void setLongitude(Double longitude) { this.longitude = longitude; }
+}

--- a/admin/src/main/java/io/meshspy/meshspy_server/request/NodeRequestController.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/request/NodeRequestController.java
@@ -1,0 +1,38 @@
+package io.meshspy.meshspy_server.request;
+
+import io.meshspy.meshspy_server.node.NodeService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/node-requests")
+public class NodeRequestController {
+    private final NodeService nodeService;
+
+    public NodeRequestController(NodeService nodeService) {
+        this.nodeService = nodeService;
+    }
+
+    @GetMapping
+    public List<NodeRegistrationRequest> listRequests() {
+        return nodeService.listRequests();
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public NodeRegistrationRequest addRequest(@RequestBody NodeRegistrationRequest request) {
+        return nodeService.addRequest(request);
+    }
+
+    @PostMapping("/{id}/approve")
+    public void approve(@PathVariable String id) {
+        nodeService.approveRequest(id);
+    }
+
+    @DeleteMapping("/{id}")
+    public void reject(@PathVariable String id) {
+        nodeService.rejectRequest(id);
+    }
+}

--- a/admin/src/main/resources/static/app.js
+++ b/admin/src/main/resources/static/app.js
@@ -19,23 +19,32 @@ async function loadNodes() {
     });
 }
 
-document.getElementById('node-form').addEventListener('submit', async e => {
-    e.preventDefault();
-    const node = {
-        id: document.getElementById('node-id').value,
-        name: document.getElementById('node-name').value,
-        address: document.getElementById('node-address').value,
-        latitude: parseFloat(document.getElementById('node-lat').value),
-        longitude: parseFloat(document.getElementById('node-lon').value)
-    };
-    await fetch('/nodes', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(node)
+async function loadRequests() {
+    const response = await fetch('/node-requests');
+    const requests = await response.json();
+    const tbody = document.querySelector('#requests tbody');
+    tbody.innerHTML = '';
+    requests.forEach(r => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${r.id}</td><td>${r.name}</td><td>${r.address}</td><td><button data-id="${r.id}" class="approve">Approve</button> <button data-id="${r.id}" class="reject">Reject</button></td>`;
+        tbody.appendChild(tr);
     });
-    e.target.reset();
+    document.querySelectorAll('.approve').forEach(btn => btn.addEventListener('click', approve));
+    document.querySelectorAll('.reject').forEach(btn => btn.addEventListener('click', reject));
+}
+
+async function approve(e) {
+    const id = e.target.dataset.id;
+    await fetch(`/node-requests/${id}/approve`, {method: 'POST'});
+    loadRequests();
     loadNodes();
-});
+}
+
+async function reject(e) {
+    const id = e.target.dataset.id;
+    await fetch(`/node-requests/${id}`, {method: 'DELETE'});
+    loadRequests();
+}
 
 function initMap() {
     map = L.map('map').setView([0, 0], 2);
@@ -47,3 +56,4 @@ function initMap() {
 
 initMap();
 loadNodes();
+loadRequests();

--- a/admin/src/main/resources/static/index.html
+++ b/admin/src/main/resources/static/index.html
@@ -17,18 +17,14 @@
                 <tbody></tbody>
             </table>
         </div>
+        <div id="request-list" class="card">
+            <h2>Pending Requests</h2>
+            <table id="requests">
+                <thead><tr><th>ID</th><th>Name</th><th>Address</th><th></th></tr></thead>
+                <tbody></tbody>
+            </table>
+        </div>
         <div id="map" class="card"></div>
-    </div>
-    <div id="add-node" class="card">
-        <h2>Add Node</h2>
-        <form id="node-form">
-            <label>ID <input type="text" id="node-id" required></label>
-            <label>Name <input type="text" id="node-name" required></label>
-            <label>Address <input type="text" id="node-address" required></label>
-            <label>Latitude <input type="number" id="node-lat" step="any"></label>
-            <label>Longitude <input type="number" id="node-lon" step="any"></label>
-            <button type="submit">Add</button>
-        </form>
     </div>
 </div>
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-sA+e2d0n0JdfM8KcVpN2zsJxxavq6b3cXwjk2f2ol3w=" crossorigin=""/>

--- a/admin/src/main/resources/static/style.css
+++ b/admin/src/main/resources/static/style.css
@@ -18,7 +18,7 @@ body {
 }
 
 .main .card {
-    flex: 1 1 45%;
+    flex: 1 1 30%;
 }
 
 .card {
@@ -59,6 +59,15 @@ button {
     border: none;
     border-radius: 4px;
     cursor: pointer;
+}
+
+.approve {
+    background-color: #28a745;
+    margin-right: 5px;
+}
+
+.reject {
+    background-color: #dc3545;
 }
 
 #map {

--- a/admin/src/test/java/io/meshspy/meshspy_server/node/NodeControllerTests.java
+++ b/admin/src/test/java/io/meshspy/meshspy_server/node/NodeControllerTests.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import io.meshspy.meshspy_server.request.NodeRegistrationRequest;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -32,6 +33,27 @@ class NodeControllerTests {
         mockMvc.perform(get("/nodes/1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("Test"));
+    }
+
+    @Test
+    void requestAndApproveNode() throws Exception {
+        NodeRegistrationRequest req = new NodeRegistrationRequest("2", "Req", "addr", 1.0, 2.0);
+
+        mockMvc.perform(post("/node-requests")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/node-requests"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value("2"));
+
+        mockMvc.perform(post("/node-requests/2/approve"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/nodes/2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Req"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add `NodeRegistrationRequest` and controller for registration requests
- extend `NodeService` to track pending requests
- update admin UI to show pending requests with approve/reject actions
- improve UI styling
- add tests for registration workflow

## Testing
- `mvn -q -pl admin test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686e76601a68832383d41856a417cc01