### PR TITLE
Add sidebar and detailed client info

### DIFF
--- a/admin/src/main/java/io/meshspy/meshspy_server/node/NodeController.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/node/NodeController.java
@@ -41,4 +41,10 @@ public class NodeController {
         nodeService.addRequestFromNode(node);
         return new ResponseEntity<>(HttpStatus.ACCEPTED);
     }
+
+    @PostMapping("/reset")
+    public void reset() {
+        log.debug("API POST /nodes/reset");
+        nodeService.reset();
+    }
 }

--- a/admin/src/main/java/io/meshspy/meshspy_server/node/NodeService.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/node/NodeService.java
@@ -48,6 +48,17 @@ public class NodeService {
         save(requestsFile, requests);
     }
 
+    public void reset() {
+        nodes.clear();
+        requests.clear();
+        try {
+            Files.deleteIfExists(nodesFile);
+            Files.deleteIfExists(requestsFile);
+        } catch (IOException e) {
+            log.warn("Failed to delete data files", e);
+        }
+    }
+
     private void save(Path file, Object data) {
         try {
             Files.createDirectories(dataDir);

--- a/admin/src/main/java/io/meshspy/meshspy_server/request/NodeRegistrationRequest.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/request/NodeRegistrationRequest.java
@@ -6,6 +6,10 @@ public class NodeRegistrationRequest {
     private String address;
     private Double latitude;
     private Double longitude;
+    private String model;
+    private String firmware;
+    private String longName;
+    private String shortName;
 
     public NodeRegistrationRequest() {}
 
@@ -15,6 +19,15 @@ public class NodeRegistrationRequest {
         this.address = address;
         this.latitude = latitude;
         this.longitude = longitude;
+    }
+
+    public NodeRegistrationRequest(String id, String name, String address, Double latitude, Double longitude,
+                                   String model, String firmware, String longName, String shortName) {
+        this(id, name, address, latitude, longitude);
+        this.model = model;
+        this.firmware = firmware;
+        this.longName = longName;
+        this.shortName = shortName;
     }
 
     public String getId() { return id; }
@@ -31,4 +44,16 @@ public class NodeRegistrationRequest {
 
     public Double getLongitude() { return longitude; }
     public void setLongitude(Double longitude) { this.longitude = longitude; }
+
+    public String getModel() { return model; }
+    public void setModel(String model) { this.model = model; }
+
+    public String getFirmware() { return firmware; }
+    public void setFirmware(String firmware) { this.firmware = firmware; }
+
+    public String getLongName() { return longName; }
+    public void setLongName(String longName) { this.longName = longName; }
+
+    public String getShortName() { return shortName; }
+    public void setShortName(String shortName) { this.shortName = shortName; }
 }

--- a/admin/src/main/resources/static/app.js
+++ b/admin/src/main/resources/static/app.js
@@ -4,14 +4,23 @@ let markers = [];
 async function loadNodes() {
     const response = await fetch('/nodes');
     const nodes = await response.json();
-    const tbody = document.querySelector('#nodes tbody');
-    tbody.innerHTML = '';
+    const nodesTable = document.querySelector('#nodes tbody');
+    const onlineTable = document.querySelector('#online tbody');
+    if (nodesTable) nodesTable.innerHTML = '';
+    if (onlineTable) onlineTable.innerHTML = '';
     markers.forEach(m => m.remove());
     markers = [];
     nodes.forEach(n => {
-        const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${n.id}</td><td>${n.name}</td><td>${n.address}</td><td>${n.latitude ?? ''}</td><td>${n.longitude ?? ''}</td>`;
-        tbody.appendChild(tr);
+        if (nodesTable) {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td>${n.id}</td><td>${n.name}</td><td>${n.address}</td><td>${n.latitude ?? ''}</td><td>${n.longitude ?? ''}</td>`;
+            nodesTable.appendChild(tr);
+        }
+        if (onlineTable) {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td>${n.id}</td><td>${n.name}</td><td>${n.address}</td>`;
+            onlineTable.appendChild(tr);
+        }
         if (n.latitude != null && n.longitude != null && map) {
             const marker = L.marker([n.latitude, n.longitude]).addTo(map).bindPopup(n.name);
             markers.push(marker);
@@ -22,15 +31,22 @@ async function loadNodes() {
 async function loadRequests() {
     const response = await fetch('/node-requests');
     const requests = await response.json();
-    const tbody = document.querySelector('#requests tbody');
-    tbody.innerHTML = '';
+    const table = document.querySelector('#requests tbody') || document.querySelector('#pending tbody');
+    if (!table) return;
+    table.innerHTML = '';
     requests.forEach(r => {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${r.id}</td><td>${r.name}</td><td>${r.address}</td><td><button data-id="${r.id}" class="approve">Approve</button> <button data-id="${r.id}" class="reject">Reject</button></td>`;
-        tbody.appendChild(tr);
+        tr.innerHTML = `<td>${r.id}</td><td>${r.name || r.longName}</td><td>${r.address}</td><td><button data-id="${r.id}" class="info-btn">i</button> <button data-id="${r.id}" class="approve">Approve</button> <button data-id="${r.id}" class="reject">Reject</button></td>`;
+        table.appendChild(tr);
+        const info = document.createElement('tr');
+        info.id = `info-${r.id}`;
+        info.classList.add('info-row', 'hidden');
+        info.innerHTML = `<td colspan="4"><strong>Model:</strong> ${r.model ?? ''}<br><strong>Firmware:</strong> ${r.firmware ?? ''}<br><strong>Longname:</strong> ${r.longName ?? ''}<br><strong>Shortname:</strong> ${r.shortName ?? ''}</td>`;
+        table.appendChild(info);
     });
     document.querySelectorAll('.approve').forEach(btn => btn.addEventListener('click', approve));
     document.querySelectorAll('.reject').forEach(btn => btn.addEventListener('click', reject));
+    document.querySelectorAll('.info-btn').forEach(btn => btn.addEventListener('click', toggleInfo));
 }
 
 async function approve(e) {
@@ -47,6 +63,8 @@ async function reject(e) {
 }
 
 function initMap() {
+    const mapEl = document.getElementById('map');
+    if (!mapEl) return;
     map = L.map('map').setView([0, 0], 2);
     L.tileLayer('leaflet/blank.png', {
         maxZoom: 3,
@@ -54,6 +72,30 @@ function initMap() {
     }).addTo(map);
 }
 
+function resetMap() {
+    if (map) {
+        map.setView([0,0], 2);
+    }
+}
+
+async function resetDb() {
+    if (confirm('Reset all nodes and requests?')) {
+        await fetch('/nodes/reset', {method: 'POST'});
+        loadNodes();
+        loadRequests();
+        resetMap();
+    }
+}
+
+function toggleInfo(e) {
+    const row = document.getElementById(`info-${e.target.dataset.id}`);
+    if (row) {
+        row.classList.toggle('hidden');
+    }
+}
+
 initMap();
 loadNodes();
 loadRequests();
+const resetBtn = document.getElementById('reset-db');
+if (resetBtn) resetBtn.addEventListener('click', resetDb);

--- a/admin/src/main/resources/static/client.html
+++ b/admin/src/main/resources/static/client.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Clients - MeshSpy</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<nav class="navbar">
+    <a href="dashboard.html">Dashboard</a>
+    <a href="index.html">Nodes</a>
+    <a href="client.html">Client</a>
+    <a href="settings.html">Settings</a>
+</nav>
+<div class="container">
+    <h1>Client Management</h1>
+    <div class="clients">
+        <div id="pending" class="card">
+            <h2>Da approvare</h2>
+            <table>
+                <thead><tr><th>ID</th><th>Name</th><th>Address</th><th>Actions</th></tr></thead>
+                <tbody></tbody>
+            </table>
+        </div>
+        <div id="online" class="card">
+            <h2>Approvati Online</h2>
+            <table>
+                <thead><tr><th>ID</th><th>Name</th><th>Address</th></tr></thead>
+                <tbody></tbody>
+            </table>
+        </div>
+        <div id="offline" class="card">
+            <h2>Offline</h2>
+            <table>
+                <thead><tr><th>ID</th><th>Name</th><th>Address</th></tr></thead>
+                <tbody></tbody>
+            </table>
+        </div>
+    </div>
+</div>
+<link rel="stylesheet" href="leaflet/leaflet.css" />
+<script src="leaflet/leaflet.js"></script>
+<script src="app.js"></script>
+</body>
+</html>

--- a/admin/src/main/resources/static/dashboard.html
+++ b/admin/src/main/resources/static/dashboard.html
@@ -10,6 +10,7 @@
 <nav class="navbar">
     <a href="dashboard.html">Dashboard</a>
     <a href="index.html">Nodes</a>
+    <a href="client.html">Client</a>
     <a href="settings.html">Settings</a>
 </nav>
 <div class="container">

--- a/admin/src/main/resources/static/index.html
+++ b/admin/src/main/resources/static/index.html
@@ -10,25 +10,22 @@
 <nav class="navbar">
     <a href="dashboard.html">Dashboard</a>
     <a href="index.html">Nodes</a>
+    <a href="client.html">Client</a>
     <a href="settings.html">Settings</a>
 </nav>
 <div class="container">
     <h1>MeshSpy Node Administration</h1>
     <div class="main">
-        <div id="node-list" class="card">
-            <h2>Nodes</h2>
-            <table id="nodes">
-                <thead><tr><th>ID</th><th>Name</th><th>Address</th><th>Lat</th><th>Lon</th></tr></thead>
-                <tbody></tbody>
-            </table>
-        </div>
-        <div id="request-list" class="card">
-            <h2>Pending Requests</h2>
-            <table id="requests">
-                <thead><tr><th>ID</th><th>Name</th><th>Address</th><th></th></tr></thead>
-                <tbody></tbody>
-            </table>
-        </div>
+        <aside id="sidebar">
+            <div id="node-list" class="card">
+                <h2>Nodes</h2>
+                <table id="nodes">
+                    <thead><tr><th>ID</th><th>Name</th><th>Address</th><th>Lat</th><th>Lon</th></tr></thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+            <button id="reset-db">Reset DB</button>
+        </aside>
         <div id="map" class="card"></div>
     </div>
 </div>

--- a/admin/src/main/resources/static/settings.html
+++ b/admin/src/main/resources/static/settings.html
@@ -10,6 +10,7 @@
 <nav class="navbar">
     <a href="dashboard.html">Dashboard</a>
     <a href="index.html">Nodes</a>
+    <a href="client.html">Client</a>
     <a href="settings.html">Settings</a>
 </nav>
 <div class="container">

--- a/admin/src/main/resources/static/style.css
+++ b/admin/src/main/resources/static/style.css
@@ -35,14 +35,35 @@ body {
     align-items: flex-start;
 }
 
+#sidebar {
+    flex: 0 0 250px;
+    display: flex;
+    flex-direction: column;
+}
+
+.clients {
+    display: flex;
+    gap: 20px;
+    flex-wrap: nowrap;
+    align-items: flex-start;
+}
+
 #node-list {
-    flex: 0 0 30%;
+    flex: 1 0 auto;
 }
 
 #map {
-    flex: 1 0 70%;
+    flex: 1 0 auto;
     height: 500px;
     background-color: #f5f7ff;
+}
+
+#pending, #online, #offline {
+    flex: 1 0 33%;
+}
+
+#reset-db {
+    margin-top: 10px;
 }
 
 .card {
@@ -91,6 +112,19 @@ button {
 
 .reject {
     background-color: #dc3545;
+}
+
+.info-btn {
+    background-color: #17a2b8;
+    margin-right: 5px;
+}
+
+.info-row {
+    background: #fafafa;
+}
+
+.hidden {
+    display: none;
 }
 
 #map {


### PR DESCRIPTION
## Summary
- add API endpoint to reset server data
- show node list in a left sidebar with DB reset button
- enhance client page table and show info popup rows
- support extra fields on registration requests
- style adjustments for sidebar and info button

## Testing
- `apt-get update -y`
- `apt-get install -y maven`
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686f0e93ca6c83238803d5408761539d