### PR TITLE
Add API usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,44 @@ The repository does not include Leaflet images to keep the history light. Run th
 
 The map attempts to load tiles from OpenStreetMap. If the tiles cannot be retrieved (for example due to blocked network access), it falls back to a blank offline tile and the map will appear empty.
 
+## Admin REST API
+
+The admin service exposes a small JSON API used by the web pages under
+`admin/src/main/resources/static` and by Meshtastic devices. When running
+`docker compose up debug-admin` the service is reachable at
+`http://localhost:8080`.
+
+### Node endpoints
+
+* `GET /nodes` – list all approved nodes.
+* `GET /nodes/{id}` – details for a single node or `404 Not Found`.
+* `POST /nodes` – register a node. If the node ID has already been approved the
+  saved node is returned with status `201 Created`; otherwise a registration
+  request is stored and the server replies with `202 Accepted`.
+* `POST /nodes/reset` – remove all nodes and requests (development only).
+
+Example request body for `POST /nodes`:
+
+```json
+{
+  "id": "AA:BB:CC",
+  "name": "Test Node",
+  "address": "192.168.1.10",
+  "latitude": 45.0,
+  "longitude": 9.0
+}
+```
+
+### Registration request endpoints
+
+* `GET /node-requests` – list pending registration requests.
+* `POST /node-requests` – create a new request. In addition to the fields above
+  it accepts `model`, `firmware`, `longName` and `shortName`.
+* `POST /node-requests/{id}/approve` – approve a request and promote the node.
+* `DELETE /node-requests/{id}` – reject and delete a request.
+
+All endpoints return JSON data.
+
 ## Planned MQTT Configuration
 
 The MQTT broker configuration is planned through a `config.json` file:


### PR DESCRIPTION
## Summary
- document admin REST API in README

## Testing
- `mvn -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686f1876e5448323bf24e63e366eb0a0