### PR TITLE
Fix reset endpoint to preserve node requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The admin service exposes a small JSON API used by the web pages under
 * `POST /nodes` – register a node. If the node ID has already been approved the
   saved node is returned with status `201 Created`; otherwise a registration
   request is stored and the server replies with `202 Accepted`.
-* `POST /nodes/reset` – remove all nodes and requests (development only).
+* `POST /nodes/reset` – remove all nodes but keep pending requests (development only).
 
 Example request body for `POST /nodes`:
 

--- a/admin/src/main/java/io/meshspy/meshspy_server/node/NodeService.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/node/NodeService.java
@@ -50,12 +50,10 @@ public class NodeService {
 
     public void reset() {
         nodes.clear();
-        requests.clear();
         try {
             Files.deleteIfExists(nodesFile);
-            Files.deleteIfExists(requestsFile);
         } catch (IOException e) {
-            log.warn("Failed to delete data files", e);
+            log.warn("Failed to delete nodes file", e);
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure `/nodes/reset` only removes approved nodes
- document new reset behavior in README

## Testing
- `mvn test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686f1d25ed1483238afd893acb66df3b