### PR TITLE
Update node registration tests

### DIFF
--- a/admin/src/test/java/io/meshspy/meshspy_server/node/NodeControllerTests.java
+++ b/admin/src/test/java/io/meshspy/meshspy_server/node/NodeControllerTests.java
@@ -7,7 +7,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import io.meshspy.meshspy_server.request.NodeRegistrationRequest;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -22,27 +21,28 @@ class NodeControllerTests {
     private ObjectMapper objectMapper;
 
     @Test
-    void addAndGetNode() throws Exception {
+    void addNodeCreatesRequest() throws Exception {
         Node node = new Node("1", "Test", "localhost", 0.0, 0.0);
 
         mockMvc.perform(post("/nodes")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(node)))
-                .andExpect(status().isCreated());
+                .andExpect(status().isAccepted());
 
         mockMvc.perform(get("/nodes/1"))
+                .andExpect(status().isNotFound());
+
+        mockMvc.perform(get("/node-requests"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.name").value("Test"));
+                .andExpect(jsonPath("$[0].id").value("1"));
     }
 
     @Test
     void requestAndApproveNode() throws Exception {
-        NodeRegistrationRequest req = new NodeRegistrationRequest("2", "Req", "addr", 1.0, 2.0);
-
-        mockMvc.perform(post("/node-requests")
+        mockMvc.perform(post("/nodes")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(req)))
-                .andExpect(status().isCreated());
+                .content(objectMapper.writeValueAsString(new Node("2", "Req", "addr", 1.0, 2.0))))
+                .andExpect(status().isAccepted());
 
         mockMvc.perform(get("/node-requests"))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## Summary
- update NodeController tests to reflect that new nodes create registration requests (HTTP 202)

## Testing
- `mvn test` *(fails: Could not transfer dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686f19ea7e908323bf5d1a68ab845912