### PR TITLE
Improve sidebar structure across pages

### DIFF
--- a/admin/src/main/resources/static/client.html
+++ b/admin/src/main/resources/static/client.html
@@ -13,29 +13,33 @@
     <a href="client.html">Client</a>
     <a href="settings.html">Settings</a>
 </nav>
-<div class="container">
-    <h1>Client Management</h1>
-    <div class="clients">
-        <div id="pending" class="card">
-            <h2>Da approvare</h2>
-            <table>
-                <thead><tr><th>ID</th><th>Name</th><th>Address</th><th>Actions</th></tr></thead>
-                <tbody></tbody>
-            </table>
-        </div>
-        <div id="online" class="card">
-            <h2>Approvati Online</h2>
-            <table>
-                <thead><tr><th>ID</th><th>Name</th><th>Address</th></tr></thead>
-                <tbody></tbody>
-            </table>
-        </div>
-        <div id="offline" class="card">
-            <h2>Offline</h2>
-            <table>
-                <thead><tr><th>ID</th><th>Name</th><th>Address</th></tr></thead>
-                <tbody></tbody>
-            </table>
+
+<div class="sidebar"></div>
+<div class="main">
+    <div class="container">
+        <h1>Client Management</h1>
+        <div class="clients">
+            <div id="pending" class="card">
+                <h2>Da approvare</h2>
+                <table>
+                    <thead><tr><th>ID</th><th>Name</th><th>Address</th><th>Actions</th></tr></thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+            <div id="online" class="card">
+                <h2>Approvati Online</h2>
+                <table>
+                    <thead><tr><th>ID</th><th>Name</th><th>Address</th></tr></thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+            <div id="offline" class="card">
+                <h2>Offline</h2>
+                <table>
+                    <thead><tr><th>ID</th><th>Name</th><th>Address</th></tr></thead>
+                    <tbody></tbody>
+                </table>
+            </div>
         </div>
     </div>
 </div>

--- a/admin/src/main/resources/static/clients.html
+++ b/admin/src/main/resources/static/clients.html
@@ -10,7 +10,7 @@
 <nav class="navbar">
     <a href="dashboard.html">Dashboard</a>
     <a href="index.html">Nodes</a>
-    <a href="clients.html">Clients</a>
+    <a href="client.html">Clients</a>
     <a href="settings.html">Settings</a>
 </nav>
 <div id="client-list" class="card sidebar">

--- a/admin/src/main/resources/static/dashboard.html
+++ b/admin/src/main/resources/static/dashboard.html
@@ -13,9 +13,13 @@
     <a href="client.html">Client</a>
     <a href="settings.html">Settings</a>
 </nav>
-<div class="container">
-    <h1>Dashboard</h1>
-    <p>Welcome to MeshSpy administration.</p>
+
+<div class="sidebar"></div>
+<div class="main">
+    <div class="container">
+        <h1>Dashboard</h1>
+        <p>Welcome to MeshSpy administration.</p>
+    </div>
 </div>
 </body>
 </html>

--- a/admin/src/main/resources/static/index.html
+++ b/admin/src/main/resources/static/index.html
@@ -10,40 +10,21 @@
 <nav class="navbar">
     <a href="dashboard.html">Dashboard</a>
     <a href="index.html">Nodes</a>
-    <a href="clients.html">Clients</a>
+    <a href="client.html">Client</a>
     <a href="settings.html">Settings</a>
 </nav>
-<div class="container">
-    <h1>MeshSpy Node Administration</h1>
-    <div id="node-list" class="card sidebar">
-        <h2>Nodes</h2>
-        <button id="reset-db">Reset DB</button>
-        <table id="nodes">
-            <thead><tr><th>ID</th><th>Name</th><th>Address</th><th>Lat</th><th>Lon</th></tr></thead>
-            <tbody></tbody>
-        </table>
-    </div>
-    <div class="main">
-        <div id="request-list" class="card">
-            <h2>Pending Requests</h2>
-            <table id="requests">
-                <thead><tr><th>ID</th><th>Name</th><th>Address</th><th></th></tr></thead>
-                <tbody></tbody>
-            </table>
-        </div>
-        <aside id="sidebar">
-            <div id="node-list" class="card">
-                <h2>Nodes</h2>
-                <table id="nodes">
-                    <thead><tr><th>ID</th><th>Name</th><th>Address</th><th>Lat</th><th>Lon</th></tr></thead>
-                    <tbody></tbody>
-                </table>
-            </div>
-            <button id="reset-db">Reset DB</button>
-        </aside>
-        <div id="map" class="card"></div>
-        <button id="reset-map">Reset Map</button>
-    </div>
+
+<div id="node-list" class="card sidebar">
+    <h2>Mesh Nodes</h2>
+    <button id="reset-db">Reset DB</button>
+    <table id="nodes">
+        <thead><tr><th>ID</th><th>Name</th><th>Address</th><th>Lat</th><th>Lon</th></tr></thead>
+        <tbody></tbody>
+    </table>
+</div>
+<div class="main">
+    <div id="map" class="card"></div>
+    <button id="reset-map">Reset Map</button>
 </div>
 <link rel="stylesheet" href="leaflet/leaflet.css" />
 <script src="leaflet/leaflet.js"></script>

--- a/admin/src/main/resources/static/settings.html
+++ b/admin/src/main/resources/static/settings.html
@@ -13,9 +13,13 @@
     <a href="client.html">Client</a>
     <a href="settings.html">Settings</a>
 </nav>
-<div class="container">
-    <h1>Settings</h1>
-    <p>Configuration options will appear here.</p>
+
+<div class="sidebar"></div>
+<div class="main">
+    <div class="container">
+        <h1>Settings</h1>
+        <p>Configuration options will appear here.</p>
+    </div>
 </div>
 </body>
 </html>

--- a/admin/src/main/resources/static/style.css
+++ b/admin/src/main/resources/static/style.css
@@ -1,14 +1,27 @@
+:root {
+    --navbar-height: 50px;
+    --sidebar-width: 250px;
+}
+
 body {
     font-family: Arial, sans-serif;
     background-color: #e8eaf6;
     margin: 0;
-    padding: 0;
+    padding-top: var(--navbar-height);
 }
 
 .navbar {
     /* Updated background to green for better visibility */
     background-color: #28a745;
     padding: 10px;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: var(--navbar-height);
+    display: flex;
+    align-items: center;
+    z-index: 1000;
 }
 
 .navbar a {
@@ -34,16 +47,16 @@ body {
     gap: 20px;
     flex-wrap: nowrap;
     align-items: flex-start;
-    margin-left: 270px;
+    margin-left: calc(var(--sidebar-width) + 20px);
 }
 
 
 .sidebar {
     position: fixed;
-    top: 0;
+    top: var(--navbar-height);
     left: 0;
-    width: 250px;
-    height: 100%;
+    width: var(--sidebar-width);
+    height: calc(100% - var(--navbar-height));
     overflow-y: auto;
 }
 
@@ -138,4 +151,19 @@ button {
     height: 400px;
     width: 100%;
     background-color: #f5f7ff;
+}
+
+@media (max-width: 768px) {
+    .navbar {
+        position: fixed;
+    }
+    .sidebar {
+        position: relative;
+        width: 100%;
+        height: auto;
+    }
+    .main {
+        margin-left: 0;
+        flex-direction: column;
+    }
 }


### PR DESCRIPTION
## Summary
- unify navbar link to client screen and standardize sidebar structure
- remove pending client table from Nodes page and keep only mesh nodes
- add consistent sidebar placeholders on all pages

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f1bbcc6508323a82dad366c3b93a5