### PR TITLE
Improve node approval name handling

### DIFF
--- a/admin/src/main/java/io/meshspy/meshspy_server/node/NodeService.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/node/NodeService.java
@@ -120,7 +120,13 @@ public class NodeService {
         NodeRegistrationRequest request = requests.remove(id);
         if (request != null) {
             log.debug("Approving request {}", id);
-            addNode(new Node(request.getId(), request.getName(), request.getAddress(), request.getLatitude(), request.getLongitude()));
+            String name = request.getName();
+            if (name == null || name.isBlank()) {
+                name = Optional.ofNullable(request.getLongName())
+                        .orElse(request.getShortName());
+            }
+            addNode(new Node(request.getId(), name, request.getAddress(),
+                    request.getLatitude(), request.getLongitude()));
             saveRequests();
         }
     }

--- a/admin/src/test/java/io/meshspy/meshspy_server/request/NodeRequestControllerTests.java
+++ b/admin/src/test/java/io/meshspy/meshspy_server/request/NodeRequestControllerTests.java
@@ -1,0 +1,44 @@
+package io.meshspy.meshspy_server.request;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class NodeRequestControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void approveRequestUsesLongNameWhenNameMissing() throws Exception {
+        NodeRegistrationRequest req = new NodeRegistrationRequest();
+        req.setId("long1");
+        req.setAddress("addr");
+        req.setLatitude(1.0);
+        req.setLongitude(2.0);
+        req.setLongName("LongNode");
+
+        mockMvc.perform(post("/node-requests")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/node-requests/long1/approve"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/nodes/long1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("LongNode"));
+    }
+}


### PR DESCRIPTION
## Summary
- fallback to `longName`/`shortName` when approving node registration requests
- test approving a request without `name`

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686f2273b5948323a21b6a8afd6a0798