### PR TITLE
Add basic node management API

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ The admin service exposes a small JSON API used by the web pages under
   request is stored and the server replies with `202 Accepted`.
 * `POST /nodes/reset` – remove all nodes but keep pending requests (development only).
 
+### Node management endpoints
+
+Endpoints for firmware configuration backups and updates are provided under `/nodes/{id}`:
+
+* `GET /nodes/{id}/backups` – list stored configuration backups for the node.
+* `POST /nodes/{id}/backup` – upload a new configuration backup.
+* `POST /nodes/{id}/restore` – restore configuration from the provided backup data.
+* `POST /nodes/{id}/firmware/update` – record a firmware update request. The payload
+  can specify a version or URL of the image to install.
+* `GET /nodes/{id}/firmware` – return the latest known firmware version for the node.
+
 Example request body for `POST /nodes`:
 
 ```json

--- a/admin/src/main/java/io/meshspy/meshspy_server/manage/ConfigBackup.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/manage/ConfigBackup.java
@@ -1,0 +1,7 @@
+package io.meshspy.meshspy_server.manage;
+
+public class ConfigBackup {
+    private String data;
+    public String getData() { return data; }
+    public void setData(String data) { this.data = data; }
+}

--- a/admin/src/main/java/io/meshspy/meshspy_server/manage/FirmwareUpdateRequest.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/manage/FirmwareUpdateRequest.java
@@ -1,0 +1,14 @@
+package io.meshspy.meshspy_server.manage;
+
+public class FirmwareUpdateRequest {
+    private String version;
+    private String url;
+    private boolean build;
+
+    public String getVersion() { return version; }
+    public void setVersion(String version) { this.version = version; }
+    public String getUrl() { return url; }
+    public void setUrl(String url) { this.url = url; }
+    public boolean isBuild() { return build; }
+    public void setBuild(boolean build) { this.build = build; }
+}

--- a/admin/src/main/java/io/meshspy/meshspy_server/manage/NodeManagementController.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/manage/NodeManagementController.java
@@ -1,0 +1,50 @@
+package io.meshspy.meshspy_server.manage;
+
+import io.meshspy.meshspy_server.node.NodeService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/nodes/{id}")
+public class NodeManagementController {
+    private static final Logger log = LoggerFactory.getLogger(NodeManagementController.class);
+    private final NodeService nodeService;
+
+    public NodeManagementController(NodeService nodeService) {
+        this.nodeService = nodeService;
+    }
+
+    @GetMapping("/backups")
+    public List<String> listBackups(@PathVariable String id) {
+        log.debug("API GET /nodes/{}/backups", id);
+        return nodeService.listBackups(id);
+    }
+
+    @PostMapping("/backup")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void addBackup(@PathVariable String id, @RequestBody ConfigBackup backup) {
+        log.debug("API POST /nodes/{}/backup", id);
+        nodeService.storeBackup(id, backup.getData());
+    }
+
+    @PostMapping("/restore")
+    public void restore(@PathVariable String id, @RequestBody ConfigBackup backup) {
+        log.debug("API POST /nodes/{}/restore", id);
+        nodeService.storeBackup(id, backup.getData());
+    }
+
+    @PostMapping("/firmware/update")
+    public void updateFirmware(@PathVariable String id, @RequestBody FirmwareUpdateRequest req) {
+        log.debug("API POST /nodes/{}/firmware/update", id);
+        nodeService.updateFirmware(id, req.getVersion());
+    }
+
+    @GetMapping("/firmware")
+    public String firmware(@PathVariable String id) {
+        return nodeService.getFirmware(id).orElse("unknown");
+    }
+}


### PR DESCRIPTION
## Summary
- sketch API endpoints for config backups and firmware updates
- keep track of backups and firmware version in `NodeService`
- update README with the new endpoints

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_686f2615fe1883239d9e48a078777a63