### PR TITLE
Handle clients separately

### DIFF
--- a/admin/src/main/java/io/meshspy/meshspy_server/node/ClientController.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/node/ClientController.java
@@ -1,0 +1,32 @@
+package io.meshspy.meshspy_server.node;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/clients")
+public class ClientController {
+    private final NodeService nodeService;
+
+    public ClientController(NodeService nodeService) {
+        this.nodeService = nodeService;
+    }
+
+    @GetMapping
+    public List<Node> listClients() {
+        return nodeService.listClients();
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Node addClient(@RequestBody Node client) {
+        return nodeService.addClient(client);
+    }
+
+    @PostMapping("/reset")
+    public void reset() {
+        nodeService.resetClients();
+    }
+}

--- a/admin/src/main/java/io/meshspy/meshspy_server/node/Node.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/node/Node.java
@@ -6,16 +6,23 @@ public class Node {
     private String address;
     private Double latitude;
     private Double longitude;
+    // true if this node represents a local client connected via USB
+    private boolean client;
 
     public Node() {
     }
 
     public Node(String id, String name, String address, Double latitude, Double longitude) {
+        this(id, name, address, latitude, longitude, false);
+    }
+
+    public Node(String id, String name, String address, Double latitude, Double longitude, boolean client) {
         this.id = id;
         this.name = name;
         this.address = address;
         this.latitude = latitude;
         this.longitude = longitude;
+        this.client = client;
     }
 
     public String getId() {
@@ -56,5 +63,13 @@ public class Node {
 
     public void setLongitude(Double longitude) {
         this.longitude = longitude;
+    }
+
+    public boolean isClient() {
+        return client;
+    }
+
+    public void setClient(boolean client) {
+        this.client = client;
     }
 }

--- a/admin/src/main/java/io/meshspy/meshspy_server/node/NodeController.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/node/NodeController.java
@@ -33,6 +33,10 @@ public class NodeController {
     @PostMapping
     public ResponseEntity<?> addNode(@RequestBody Node node) {
         log.debug("API POST /nodes {}", node.getId());
+        if (node.isClient()) {
+            Node saved = nodeService.addClient(node);
+            return new ResponseEntity<>(saved, HttpStatus.CREATED);
+        }
         if (nodeService.isApproved(node.getId())) {
             Node saved = nodeService.addNode(node);
             return new ResponseEntity<>(saved, HttpStatus.CREATED);

--- a/admin/src/main/resources/static/clients.js
+++ b/admin/src/main/resources/static/clients.js
@@ -50,7 +50,7 @@ function initMap() {
 }
 
 async function resetDb() {
-    await fetch('/nodes/reset', {method:'POST'});
+    await fetch('/clients/reset', {method:'POST'});
     loadClients();
 }
 

--- a/admin/src/main/resources/static/style.css
+++ b/admin/src/main/resources/static/style.css
@@ -59,6 +59,7 @@ body {
     width: var(--sidebar-width);
     height: calc(100% - var(--navbar-height));
     overflow-y: auto;
+    overflow-x: auto;
 }
 
 .clients {
@@ -99,6 +100,11 @@ body {
 table {
     width: 100%;
     border-collapse: collapse;
+}
+
+#node-list table {
+    table-layout: fixed;
+    word-break: break-word;
 }
 
 thead {


### PR DESCRIPTION
## Summary
- add `client` flag to Node for USB-connected devices
- track connected clients in NodeService
- expose new `/clients` REST API
- filter clients when adding nodes
- update client-side reset URL
- improve sidebar overflow handling

## Testing
- `./mvnw test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_686f29e6669483239247d46069853d80