### PR TITLE
Implement dotenv support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ admin/target/
 local/target/
 admin/src/main/resources/static/leaflet/images/
 admin/src/main/resources/static/leaflet/blank.png
+.env

--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ The repository does not include Leaflet images to keep the history light. Run th
 ```
 
 The map attempts to load tiles from OpenStreetMap. If the tiles cannot be retrieved (for example due to blocked network access), it falls back to a blank offline tile and the map will appear empty.
+
+### Environment configuration
+
+Both the admin and local modules automatically load variables from a `.env` file at startup. You can override default paths or other settings by creating a file named `.env` in the project root:
+
+```properties
+ADMIN_DATA_DIR=/path/to/data
+```
+
+Values provided via real environment variables still take precedence over the contents of `.env`.
 ## Admin REST API
 
 The admin service exposes a small JSON API used by the web pages under

--- a/README_Italian.md
+++ b/README_Italian.md
@@ -74,6 +74,16 @@ La UI sarà accessibile su `http://localhost:5173` (in fase di sviluppo).
 docker-compose up -d
 ```
 
+### Configurazione tramite `.env`
+
+I moduli admin e local caricano automaticamente le variabili definite in un file `.env` posizionato nella directory principale del progetto. Ad esempio è possibile impostare la cartella in cui salvare i dati del servizio admin specificando:
+
+```properties
+ADMIN_DATA_DIR=/percorso/dati
+```
+
+Le variabili d'ambiente reali hanno comunque precedenza sui valori presenti nel file `.env`.
+
 ## Contribuire
 
 Se desideri contribuire al progetto, sentiti libero di aprire issue, proporre modifiche o miglioramenti tramite pull request.

--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -18,6 +18,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.github.cdimascio</groupId>
+            <artifactId>dotenv-java</artifactId>
+            <version>3.2.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/admin/src/main/java/io/meshspy/meshspy_server/AdminMeshSpyServerApplication.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/AdminMeshSpyServerApplication.java
@@ -2,12 +2,18 @@ package io.meshspy.meshspy_server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import io.github.cdimascio.dotenv.Dotenv;
 
 @SpringBootApplication
 public class AdminMeshSpyServerApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(AdminMeshSpyServerApplication.class, args);
-	}
+        public static void main(String[] args) {
+                Dotenv.configure()
+                        .ignoreIfMalformed()
+                        .ignoreIfMissing()
+                        .systemProperties()
+                        .load();
+                SpringApplication.run(AdminMeshSpyServerApplication.class, args);
+        }
 
 }

--- a/admin/src/main/java/io/meshspy/meshspy_server/node/NodeService.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/node/NodeService.java
@@ -28,12 +28,26 @@ public class NodeService {
     private final Map<String, String> firmware = new HashMap<>();
 
     private final ObjectMapper mapper = new ObjectMapper();
-    private final Path dataDir = Paths.get(Optional.ofNullable(System.getProperty("admin.data.dir")).orElse("data"));
+    private final Path dataDir = Paths.get(resolveDataDir());
     private final Path nodesFile = dataDir.resolve("nodes.json");
     private final Path clientsFile = dataDir.resolve("clients.json");
     private final Path requestsFile = dataDir.resolve("requests.json");
     private final Path backupsFile = dataDir.resolve("backups.json");
     private final Path firmwareFile = dataDir.resolve("firmware.json");
+
+    private static String resolveDataDir() {
+        String dir = System.getProperty("admin.data.dir");
+        if (dir == null || dir.isBlank()) {
+            dir = System.getProperty("ADMIN_DATA_DIR");
+        }
+        if (dir == null || dir.isBlank()) {
+            dir = System.getenv("ADMIN_DATA_DIR");
+        }
+        if (dir == null || dir.isBlank()) {
+            dir = "data";
+        }
+        return dir;
+    }
 
     @PostConstruct
     private void load() {

--- a/local/pom.xml
+++ b/local/pom.xml
@@ -14,6 +14,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.github.cdimascio</groupId>
+            <artifactId>dotenv-java</artifactId>
+            <version>3.2.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/local/src/main/java/io/meshspy/meshspy_server/LocalMeshSpyServerApplication.java
+++ b/local/src/main/java/io/meshspy/meshspy_server/LocalMeshSpyServerApplication.java
@@ -2,12 +2,18 @@ package io.meshspy.meshspy_server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import io.github.cdimascio.dotenv.Dotenv;
 
 @SpringBootApplication
 public class LocalMeshSpyServerApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(LocalMeshSpyServerApplication.class, args);
-	}
+        public static void main(String[] args) {
+                Dotenv.configure()
+                        .ignoreIfMalformed()
+                        .ignoreIfMissing()
+                        .systemProperties()
+                        .load();
+                SpringApplication.run(LocalMeshSpyServerApplication.class, args);
+        }
 
 }


### PR DESCRIPTION
## Summary
- allow dotenv configuration via `.env` file
- document the new behaviour in the READMEs
- ignore `.env` in git

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687545762a1c8323a8483922c78cfbcc