### PR TITLE
Add client approval workflow and data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,13 @@ The admin service exposes a small JSON API used by the web pages under
 Endpoints for local clients physically connected via USB:
 
 * `GET /clients` – list connected clients.
-* `POST /clients` – register a new client using the same payload as `POST /nodes` with `"client": true`.
+* `POST /clients` – register a new client using the same payload as `POST /nodes` with `"client": true`. If the client is not yet approved the request is stored and the server replies with `202 Accepted`.
 * `POST /clients/reset` – remove all stored clients.
+* `GET /client-requests` – list pending client registration requests.
+* `POST /client-requests/{id}/approve` – approve a pending client.
+* `DELETE /client-requests/{id}` – reject a client request.
+* `POST /clients/{id}/data` – send generic data from the client.
+* `GET /clients/{id}/data` – list all received data for the client.
 
 ### Node management endpoints
 
@@ -157,6 +162,29 @@ The option to launch MeshSpy with Docker is planned:
 ```bash
 docker-compose up -d
 ```
+
+## Example client implementation
+
+Approved clients can periodically send their data to the admin service. Below is a minimal Python example that registers a client and posts some data:
+
+```python
+import requests
+
+client = {
+    "id": "USB01",
+    "name": "Local USB client",
+    "client": True
+}
+
+resp = requests.post("http://localhost:8080/clients", json=client)
+if resp.status_code == 202:
+    print("Waiting for approval...")
+    exit()
+
+requests.post(f"http://localhost:8080/clients/{client['id']}/data", data="hello")
+```
+
+After approval, the data sent by the client can be retrieved with `GET /clients/{id}/data`.
 
 ## Contributing
 

--- a/README_Italian.md
+++ b/README_Italian.md
@@ -74,6 +74,29 @@ La UI sarà accessibile su `http://localhost:5173` (in fase di sviluppo).
 docker-compose up -d
 ```
 
+## Esempio di implementazione del client
+
+I client approvati possono inviare periodicamente i propri dati al servizio admin. Di seguito un semplice esempio in Python:
+
+```python
+import requests
+
+client = {
+    "id": "USB01",
+    "name": "Client locale",
+    "client": True
+}
+
+resp = requests.post("http://localhost:8080/clients", json=client)
+if resp.status_code == 202:
+    print("In attesa di approvazione...")
+    exit()
+
+requests.post(f"http://localhost:8080/clients/{client['id']}/data", data="ciao")
+```
+
+Dopo l'approvazione, i dati inviati dal client possono essere recuperati con `GET /clients/{id}/data`.
+
 ## Contribuire
 
 Se desideri contribuire al progetto, sentiti libero di aprire issue, proporre modifiche o miglioramenti tramite pull request.

--- a/admin/src/main/java/io/meshspy/meshspy_server/node/ClientController.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/node/ClientController.java
@@ -1,6 +1,7 @@
 package io.meshspy.meshspy_server.node;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -20,9 +21,13 @@ public class ClientController {
     }
 
     @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
-    public Node addClient(@RequestBody Node client) {
-        return nodeService.addClient(client);
+    public ResponseEntity<?> addClient(@RequestBody Node client) {
+        if (nodeService.isClientApproved(client.getId())) {
+            Node saved = nodeService.addClient(client);
+            return new ResponseEntity<>(saved, HttpStatus.CREATED);
+        }
+        nodeService.addClientRequestFromNode(client);
+        return new ResponseEntity<>(HttpStatus.ACCEPTED);
     }
 
     @PostMapping("/reset")

--- a/admin/src/main/java/io/meshspy/meshspy_server/node/ClientDataController.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/node/ClientDataController.java
@@ -1,0 +1,32 @@
+package io.meshspy.meshspy_server.node;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/clients/{id}/data")
+public class ClientDataController {
+    private static final Logger log = LoggerFactory.getLogger(ClientDataController.class);
+    private final NodeService nodeService;
+
+    public ClientDataController(NodeService nodeService) {
+        this.nodeService = nodeService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public void addData(@PathVariable String id, @RequestBody String data) {
+        log.debug("API POST /clients/{}/data", id);
+        nodeService.storeClientData(id, data);
+    }
+
+    @GetMapping
+    public List<String> listData(@PathVariable String id) {
+        log.debug("API GET /clients/{}/data", id);
+        return nodeService.listClientData(id);
+    }
+}

--- a/admin/src/main/java/io/meshspy/meshspy_server/request/ClientRequestController.java
+++ b/admin/src/main/java/io/meshspy/meshspy_server/request/ClientRequestController.java
@@ -1,0 +1,46 @@
+package io.meshspy.meshspy_server.request;
+
+import io.meshspy.meshspy_server.node.NodeService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/client-requests")
+public class ClientRequestController {
+    private static final Logger log = LoggerFactory.getLogger(ClientRequestController.class);
+    private final NodeService nodeService;
+
+    public ClientRequestController(NodeService nodeService) {
+        this.nodeService = nodeService;
+    }
+
+    @GetMapping
+    public List<NodeRegistrationRequest> listRequests() {
+        log.debug("API GET /client-requests");
+        return nodeService.listClientRequests();
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public NodeRegistrationRequest addRequest(@RequestBody NodeRegistrationRequest request) {
+        log.debug("API POST /client-requests {}", request.getId());
+        nodeService.addClientRequestFromNode(new io.meshspy.meshspy_server.node.Node(request.getId(), request.getName(), request.getAddress(), request.getLatitude(), request.getLongitude(), true));
+        return request;
+    }
+
+    @PostMapping("/{id}/approve")
+    public void approve(@PathVariable String id) {
+        log.debug("API POST /client-requests/{}/approve", id);
+        nodeService.approveClientRequest(id);
+    }
+
+    @DeleteMapping("/{id}")
+    public void reject(@PathVariable String id) {
+        log.debug("API DELETE /client-requests/{}", id);
+        nodeService.rejectClientRequest(id);
+    }
+}


### PR DESCRIPTION
## Summary
- manage client approval with a new request queue
- add endpoints to push and query client data
- document the new API and provide example client code (EN and IT)

## Testing
- `mvn -q -pl admin test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6876ee96a0bc83238678f44be7ca1746