### PR TITLE
Fix build plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
                         <plugin>
                                 <groupId>pl.project13.maven</groupId>
                                 <artifactId>git-commit-id-plugin</artifactId>
-                                <version>5.0.0</version>
+                                <version>4.9.10</version>
                                 <executions>
                                         <execution>
                                                 <goals>


### PR DESCRIPTION
## Summary
- fix the git-commit-id Maven plugin version so Maven can resolve it

## Testing
- `mvn -DskipTests clean package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68774920cef88323917714c78b9568a7