### PR TITLE
Add API context path for admin endpoints

### DIFF
--- a/admin/src/main/resources/application.properties
+++ b/admin/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.application.name=AdminMeshSpy-Server
 logging.level.root=DEBUG
+server.servlet.context-path=/api


### PR DESCRIPTION
## Summary
- set context path `/api` for the admin module

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687767ee8d108323bd19c85cdf4785d9